### PR TITLE
Colormap alpha

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -200,6 +200,8 @@ class _AxesImageBase(martist.Artist, cm.ScalarMappable):
             else:
                 if self._rgbacache is None:
                     x = self.to_rgba(self._A, bytes=True)
+                    # premultiply the colors
+                    x[...,0:3] *= x[...,3:4] / 255.0
                     self._rgbacache = x
                 else:
                     x = self._rgbacache


### PR DESCRIPTION
A probable solution to the "weird color" problem displaying colormapped images where the colormap has alpha values.  Agg (and the PDF and SVG backends for that matter) expect images to have premultiplied alpha.
